### PR TITLE
Fix for using callable_traits as a CMake dependency in other boost projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,16 +5,16 @@
 # (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
 cmake_minimum_required(VERSION 3.0)
-project(callable_traits CXX)
+project(boost_callable_traits CXX)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 enable_testing()
 
-set (CMAKE_CXX_STANDARD ${callable_traits_CXX_STD})
+set (CMAKE_CXX_STANDARD ${boost_callable_traits_CXX_STD})
 
 # Setting up CMake options and compiler flags (more flags can be set on a per-target basis or in subdirectories)
 
 include(CheckCXXCompilerFlag)
-macro(callable_traits_append_flag testname flag)
+macro(boost_callable_traits_append_flag testname flag)
     check_cxx_compiler_flag(${flag} ${testname})
     if (${testname})
         add_compile_options(${flag})
@@ -24,37 +24,47 @@ endmacro()
 if(NOT MSVC OR ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
 
     # enable all warnings and treat them all as errors
-    callable_traits_append_flag(callable_traits_HAS_WERROR -Werror)
-    callable_traits_append_flag(callable_traits_HAS_WX -WX)
-    callable_traits_append_flag(callable_traits_HAS_W                          -W)
-    callable_traits_append_flag(callable_traits_HAS_WALL                       -Wall)
-    callable_traits_append_flag(callable_traits_HAS_WEXTRA                     -Wextra)
+    boost_callable_traits_append_flag(boost_callable_traits_HAS_WERROR -Werror)
+    boost_callable_traits_append_flag(boost_callable_traits_HAS_WX -WX)
+    boost_callable_traits_append_flag(boost_callable_traits_HAS_W                          -W)
+    boost_callable_traits_append_flag(boost_callable_traits_HAS_WALL                       -Wall)
+    boost_callable_traits_append_flag(boost_callable_traits_HAS_WEXTRA                     -Wextra)
 endif()
 
 if(MSVC)
 
     # MSVC/Clang-cl builds need -Qunused-arguments
-    callable_traits_append_flag(callable_traits_HAS_QUNUSED_ARGUMENTS          -Qunused-arguments)
+    boost_callable_traits_append_flag(boost_callable_traits_HAS_QUNUSED_ARGUMENTS          -Qunused-arguments)
 else()
 
     # for better template error debugging
-    callable_traits_append_flag(callable_traits_HAS_FTEMPLATE_BACKTRACE_LIMIT  -ftemplate-backtrace-limit=0)
+    boost_callable_traits_append_flag(boost_callable_traits_HAS_FTEMPLATE_BACKTRACE_LIMIT  -ftemplate-backtrace-limit=0)
     
     # enforce strict standards compliance
-    callable_traits_append_flag(callable_traits_HAS_PEDANTIC                   -pedantic)
+    boost_callable_traits_append_flag(boost_callable_traits_HAS_PEDANTIC                   -pedantic)
     
     # use the most recent C++ standard available
-    callable_traits_append_flag(callable_traits_HAS_STDCXX0x                   -std=c++0x)
-    callable_traits_append_flag(callable_traits_HAS_STDCXX1y                   -std=c++1y)
-    callable_traits_append_flag(callable_traits_HAS_STDCXX1z                   -std=c++1z)
-    callable_traits_append_flag(callable_traits_HAS_STDCXX17                   -std=c++17)
-    callable_traits_append_flag(callable_traits_HAS_STDCXX2a                   -std=c++2a)
+    boost_callable_traits_append_flag(boost_callable_traits_HAS_STDCXX0x                   -std=c++0x)
+    boost_callable_traits_append_flag(boost_callable_traits_HAS_STDCXX1y                   -std=c++1y)
+    boost_callable_traits_append_flag(boost_callable_traits_HAS_STDCXX1z                   -std=c++1z)
+    boost_callable_traits_append_flag(boost_callable_traits_HAS_STDCXX17                   -std=c++17)
+    boost_callable_traits_append_flag(boost_callable_traits_HAS_STDCXX2a                   -std=c++2a)
 endif()
 
 # transactional memory - currently only available in GCC 6 and later
 if(NOT ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
-    callable_traits_append_flag(callable_traits_HAS_FGNU_TM                    -fgnu-tm)
+    boost_callable_traits_append_flag(boost_callable_traits_HAS_FGNU_TM                    -fgnu-tm)
 endif()
+
+add_library(boost_callable_traits INTERFACE)
+set_property(TARGET boost_callable_traits PROPERTY EXPORT_NAME callable_traits)
+add_library(Boost::callable_traits ALIAS boost_callable_traits)
+
+target_include_directories(boost_callable_traits INTERFACE
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    $<INSTALL_INTERFACE:include>)
+
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
 
 #
 #find_package(Doxygen)
@@ -63,35 +73,35 @@ endif()
 #find_package(Ruby 2.1)
 
 ##############################################################################
-# callable_traits_target_name_for(<output variable> <source file> [ext])
+# boost_callable_traits_target_name_for(<output variable> <source file> [ext])
 # Returns the target name associated to a source file. If the path of the
-# source file relative from the root of callable_traits is `path/to/source/file.ext`,
+# source file relative from the root of boost_callable_traits is `path/to/source/file.ext`,
 # the target name associated to it will be `path.to.source.file`.
 #
 # The extension of the file should be specified as a last argument. If no
 # extension is specified, the `.cpp` extension is assumed.
 ##############################################################################
 
-function(callable_traits_target_name_for out file)
+function(boost_callable_traits_target_name_for out file)
     if (NOT ARGV2)
         set(_extension ".cpp")
     else()
         set(_extension "${ARGV2}")
     endif()
 
-    file(RELATIVE_PATH _relative ${callable_traits_SOURCE_DIR} ${file})
+    file(RELATIVE_PATH _relative ${boost_callable_traits_SOURCE_DIR} ${file})
     string(REPLACE "${_extension}" "" _name ${_relative})
     string(REGEX REPLACE "/" "." _name ${_name})
     set(${out} "${_name}" PARENT_SCOPE)
 endfunction()
 
 ##############################################################################
-# callable_traits_add_test(<name> <command> [<arg>...])
+# boost_callable_traits_add_test(<name> <command> [<arg>...])
 # Creates a test called `name`, which runs the given `command` with the given args.
 ##############################################################################
 
-function(callable_traits_add_test name)
-    if (callable_traits_ENABLE_MEMCHECK)
+function(boost_callable_traits_add_test name)
+    if (boost_callable_traits_ENABLE_MEMCHECK)
         add_test(${name} ${Valgrind_EXECUTABLE} --leak-check=full --error-exitcode=1 ${ARGN})
     else()
         add_test(${name} ${ARGN})
@@ -101,7 +111,6 @@ endfunction()
 ##############################################################################
 # Setup the `check` target to build and then run all the tests and examples.
 ##############################################################################
-
 
 add_custom_target(callable_traits_check
     COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
@@ -119,10 +128,8 @@ add_subdirectory(test)
 ##############################################################################
 # Setup the 'install' target and the package config file.
 ##############################################################################
-add_library(callable_traits INTERFACE)
-target_include_directories(callable_traits INTERFACE
-    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-    $<INSTALL_INTERFACE:include>)
-install(TARGETS callable_traits     EXPORT CallableTraitsConfig)
+install(TARGETS boost_callable_traits     EXPORT CallableTraitsConfig)
 install(EXPORT CallableTraitsConfig DESTINATION lib/cmake/CallableTraits)
 install(DIRECTORY include/boost     DESTINATION include FILES_MATCHING PATTERN "*.hpp")
+
+endif()

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -6,7 +6,7 @@
 add_custom_target(examples COMMENT "Build all the examples.")
 add_dependencies(callable_traits_check examples)
 
-include_directories(${callable_traits_SOURCE_DIR}/include)
+include_directories(${boost_callable_traits_SOURCE_DIR}/include)
 
 file(GLOB_RECURSE EXAMPLES "*.cpp")
 file(GLOB_RECURSE EXPERIMENTAL_EXAMPLES "experimental*.cpp")
@@ -18,8 +18,8 @@ if (NOT BOOST_CLBL_TRTS_BUILD_EXPERIMENTAL)
 endif()
 
 foreach(_file IN LISTS EXAMPLES)
-    callable_traits_target_name_for(_target "${_file}")
+    boost_callable_traits_target_name_for(_target "${_file}")
     add_executable(${_target} EXCLUDE_FROM_ALL "${_file}")
-    callable_traits_add_test(${_target} ${CMAKE_CURRENT_BINARY_DIR}/${_target})
+    boost_callable_traits_add_test(${_target} ${CMAKE_CURRENT_BINARY_DIR}/${_target})
     add_dependencies(examples ${_target})
 endforeach()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,28 +14,28 @@ add_custom_target(tests.quick COMMENT "Build a subset of all the unit tests to f
 # dependency of the `tests` target.
 ##############################################################################
 
-function(callable_traits_add_unit_test name)
-    callable_traits_add_test(${ARGV})
+function(boost_callable_traits_add_unit_test name)
+    boost_callable_traits_add_test(${ARGV})
     add_dependencies(tests ${name})
     if ((NOT "${name}" MATCHES "\\.ext\\.") AND (NOT "${name}" MATCHES "_mcd"))
         add_dependencies(tests.quick ${name})
     endif()
 endfunction()
 
-include_directories(${callable_traits_SOURCE_DIR}/include)
+include_directories(${boost_callable_traits_SOURCE_DIR}/include)
 include_directories(${CMAKE_CURRENT_LIST_DIR}/include)
 include_directories(${CMAKE_CURRENT_LIST_DIR})
 
 file(GLOB_RECURSE UNIT_TESTS "*.cpp")
 
 foreach(_file IN LISTS UNIT_TESTS)
-    callable_traits_target_name_for(_target "${_file}")
+    boost_callable_traits_target_name_for(_target "${_file}")
     add_executable(${_target} EXCLUDE_FROM_ALL "${_file}")
     set(lazy_target "lazy_${_target}")
     add_executable(${lazy_target} EXCLUDE_FROM_ALL "${_file}")
     target_compile_definitions(${lazy_target} INTERFACE -DUSE_LAZY_TYPES)
-    callable_traits_add_unit_test(${_target} ${CMAKE_CURRENT_BINARY_DIR}/${_target})
-    callable_traits_add_unit_test(${lazy_target} ${CMAKE_CURRENT_BINARY_DIR}/${_target})
+    boost_callable_traits_add_unit_test(${_target} ${CMAKE_CURRENT_BINARY_DIR}/${_target})
+    boost_callable_traits_add_unit_test(${lazy_target} ${CMAKE_CURRENT_BINARY_DIR}/${_target})
 endforeach()
 
 add_dependencies(callable_traits_check tests)


### PR DESCRIPTION
This fixes the problems described in #182.